### PR TITLE
Add guild-specific filtering to reminder list

### DIFF
--- a/.output.txt
+++ b/.output.txt
@@ -1,0 +1,228 @@
+
+> scrum-owl@1.0.0 test
+> jest
+(node:70758) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+ PASS  src/__tests__/reminderService.test.ts
+(node:70757) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+ PASS  src/__tests__/storage.test.ts
+  ● Console
+    console.error
+      Error loading reminders: SyntaxError: Unexpected token 'i', "invalid json" is not valid JSON
+          at JSON.parse (<anonymous>)
+          at ReminderStorage.loadReminders (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/utils/storage.ts:19:30)
+          at Object.<anonymous> (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/__tests__/storage.test.ts:60:39)
+          at Promise.then.completed (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/utils.js:298:28)
+          at new Promise (<anonymous>)
+          at callAsyncCircusFn (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/utils.js:231:10)
+          at _callCircusTest (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:316:40)
+          at processTicksAndRejections (node:internal/process/task_queues:105:5)
+          at _runTest (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:252:3)
+          at _runTestsForDescribeBlock (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:126:9)
+          at _runTestsForDescribeBlock (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:121:9)
+          at _runTestsForDescribeBlock (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:121:9)
+          at run (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:71:3)
+          at runAndTransformResultsToJestFormat (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+          at jestAdapter (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
+          at runTestInternal (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-runner/build/runTest.js:367:16)
+          at runTest (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-runner/build/runTest.js:444:34)
+          at Object.worker (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-runner/build/testWorker.js:106:12)
+      31 |       }));
+      32 |     } catch (error) {
+    > 33 |       console.error('Error loading reminders:', error);
+         |               ^
+      34 |       return [];
+      35 |     }
+      36 |   }
+      at ReminderStorage.loadReminders (src/utils/storage.ts:33:15)
+      at Object.<anonymous> (src/__tests__/storage.test.ts:60:39)
+    console.error
+      Error saving reminders: Error: Write failed
+          at Object.<anonymous> (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/__tests__/storage.test.ts:114:15)
+          at /Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-environment-node/node_modules/jest-mock/build/index.js:397:39
+          at Object.<anonymous> (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-environment-node/node_modules/jest-mock/build/index.js:404:13)
+          at Object.mockConstructor (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-environment-node/node_modules/jest-mock/build/index.js:148:19)
+          at Object.writeFileSync (eval at _createMockFunction (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-environment-node/node_modules/jest-mock/build/index.js:566:31), <anonymous>:3:59)
+          at ReminderStorage.saveReminders (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/utils/storage.ts:45:10)
+          at Object.<anonymous> (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/__tests__/storage.test.ts:117:28)
+          at Promise.then.completed (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/utils.js:298:28)
+          at new Promise (<anonymous>)
+          at callAsyncCircusFn (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/utils.js:231:10)
+          at _callCircusTest (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:316:40)
+          at processTicksAndRejections (node:internal/process/task_queues:105:5)
+          at _runTest (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:252:3)
+          at _runTestsForDescribeBlock (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:126:9)
+          at _runTestsForDescribeBlock (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:121:9)
+          at _runTestsForDescribeBlock (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:121:9)
+          at run (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:71:3)
+          at runAndTransformResultsToJestFormat (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+          at jestAdapter (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
+          at runTestInternal (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-runner/build/runTest.js:367:16)
+          at runTest (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-runner/build/runTest.js:444:34)
+          at Object.worker (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-runner/build/testWorker.js:106:12)
+      45 |       fs.writeFileSync(this.dataPath, JSON.stringify(reminders, null, 2), 'utf8');
+      46 |     } catch (error) {
+    > 47 |       console.error('Error saving reminders:', error);
+         |               ^
+      48 |       throw error;
+      49 |     }
+      50 |   }
+      at ReminderStorage.saveReminders (src/utils/storage.ts:47:15)
+      at Object.<anonymous> (src/__tests__/storage.test.ts:117:28)
+(node:70755) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+ PASS  src/__tests__/reminder.test.ts
+ PASS  src/services/__tests__/quickChartService.test.ts
+(node:70754) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+ PASS  src/__tests__/planningPoker.test.ts
+(node:70756) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:70753) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+ PASS  src/__tests__/facilitator.test.ts
+ PASS  src/__tests__/reminderScheduler.test.ts
+  ● Console
+    console.log
+      [ReminderScheduler] Starting reminder scheduler...
+      at ReminderScheduler.start (src/services/reminderScheduler.ts:23:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler started
+      at ReminderScheduler.start (src/services/reminderScheduler.ts:36:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Starting reminder scheduler...
+      at ReminderScheduler.start (src/services/reminderScheduler.ts:23:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler started
+      at ReminderScheduler.start (src/services/reminderScheduler.ts:36:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Starting reminder scheduler...
+      at ReminderScheduler.start (src/services/reminderScheduler.ts:23:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler started
+      at ReminderScheduler.start (src/services/reminderScheduler.ts:36:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Triggered reminder: Test Reminder for user user123
+      at ReminderScheduler.triggerReminder (src/services/reminderScheduler.ts:147:15)
+    console.log
+      [ReminderScheduler] Deactivated reminder: Test Reminder
+      at ReminderScheduler.deactivateReminder (src/services/reminderScheduler.ts:179:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.error
+      [ReminderScheduler] Error triggering reminder test-id-1: Error: Channel not found
+          at Object.<anonymous> (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/__tests__/reminderScheduler.test.ts:125:66)
+          at Promise.then.completed (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/utils.js:298:28)
+          at new Promise (<anonymous>)
+          at callAsyncCircusFn (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/utils.js:231:10)
+          at _callCircusTest (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:316:40)
+          at processTicksAndRejections (node:internal/process/task_queues:105:5)
+          at _runTest (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:252:3)
+          at _runTestsForDescribeBlock (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:126:9)
+          at _runTestsForDescribeBlock (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:121:9)
+          at _runTestsForDescribeBlock (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:121:9)
+          at run (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/run.js:71:3)
+          at runAndTransformResultsToJestFormat (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
+          at jestAdapter (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
+          at runTestInternal (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-runner/build/runTest.js:367:16)
+          at runTest (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-runner/build/runTest.js:444:34)
+          at Object.worker (/Users/makinotakashi/Workspace/nextjs/scrum-master/node_modules/jest-runner/build/testWorker.js:106:12)
+      154 |       }
+      155 |     } catch (error) {
+    > 156 |       console.error(`[ReminderScheduler] Error triggering reminder ${reminder.id}:`, error);
+          |               ^
+      157 |     }
+      158 |   }
+      159 |
+      at ReminderScheduler.triggerReminder (src/services/reminderScheduler.ts:156:15)
+      at ReminderScheduler.checkReminders (src/services/reminderScheduler.ts:68:11)
+      at Object.<anonymous> (src/__tests__/reminderScheduler.test.ts:127:7)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Deactivated reminder: Test Reminder
+      at ReminderScheduler.deactivateReminder (src/services/reminderScheduler.ts:179:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+    console.log
+      [ReminderScheduler] Reminder scheduler stopped
+      at ReminderScheduler.stop (src/services/reminderScheduler.ts:45:13)
+(node:70752) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+ PASS  src/__tests__/reminderCommand.test.ts
+  ● Console
+    console.error
+      [Reminder Command] Error: TypeError: Cannot read properties of undefined (reading 'title')
+          at handleCreate (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/commands/reminder.ts:205:35)
+          at processTicksAndRejections (node:internal/process/task_queues:105:5)
+          at Object.execute (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/commands/reminder.ts:102:11)
+          at Object.<anonymous> (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/__tests__/reminderCommand.test.ts:71:7)
+      118 |       }
+      119 |     } catch (error) {
+    > 120 |       console.error('[Reminder Command] Error:', error);
+          |               ^
+      121 |       const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+      122 |
+      123 |       if (interaction.replied || interaction.deferred) {
+      at Object.execute (src/commands/reminder.ts:120:15)
+      at Object.<anonymous> (src/__tests__/reminderCommand.test.ts:71:7)
+    console.error
+      [Reminder Command] Error: TypeError: Cannot read properties of undefined (reading 'title')
+          at handleCreate (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/commands/reminder.ts:205:35)
+          at processTicksAndRejections (node:internal/process/task_queues:105:5)
+          at Object.execute (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/commands/reminder.ts:102:11)
+          at Object.<anonymous> (/Users/makinotakashi/Workspace/nextjs/scrum-master/src/__tests__/reminderCommand.test.ts:82:7)
+      118 |       }
+      119 |     } catch (error) {
+    > 120 |       console.error('[Reminder Command] Error:', error);
+          |               ^
+      121 |       const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+      122 |
+      123 |       if (interaction.replied || interaction.deferred) {
+      at Object.execute (src/commands/reminder.ts:120:15)
+      at Object.<anonymous> (src/__tests__/reminderCommand.test.ts:82:7)
+Test Suites: 8 passed, 8 total
+Tests:       79 passed, 79 total
+Snapshots:   0 total
+Time:        4.269 s
+Ran all test suites.

--- a/notes/features/guild-specific-reminder-list.md
+++ b/notes/features/guild-specific-reminder-list.md
@@ -1,0 +1,47 @@
+# Guild-Specific Reminder List Feature
+
+## Issue Description
+When using the reminder list command, users should only see reminders registered within the current guild, not reminders from all guilds they're in.
+
+## Current Problem
+- The `/reminder list` command calls `reminderService.getUserReminders(interaction.user.id)`
+- This method only filters by user ID, showing reminders from all guilds
+- Users can see reminders from different Discord servers they're in
+
+## Analysis
+- Guild ID is already stored in reminder data structure (`guildId` field)
+- `ReminderStorage.getRemindersByUser()` only filters by `userId`
+- Need to add guild-based filtering to the storage layer
+- Need to modify the service layer to use guild-specific filtering
+- Need to update the command to pass guild ID
+
+## Implementation Plan
+
+### 1. Storage Layer Changes (src/utils/storage.ts)
+- Add new method `getRemindersByUserAndGuild(userId: string, guildId: string): Promise<Reminder[]>`
+- This method will filter reminders by both user ID and guild ID
+
+### 2. Service Layer Changes (src/services/reminderService.ts)
+- Add new method `getUserRemindersInGuild(userId: string, guildId: string): Promise<Reminder[]>`
+- This will use the new storage method
+
+### 3. Command Layer Changes (src/commands/reminder.ts)
+- Update `handleList` function to use `getUserRemindersInGuild` instead of `getUserReminders`
+- Pass `interaction.guildId` along with `interaction.user.id`
+
+### 4. Test Changes
+- Add tests for the new storage method
+- Add tests for the new service method
+- Update existing tests to ensure guild filtering works correctly
+
+## Edge Cases to Consider
+- What if `interaction.guildId` is null (DM context)?
+- Ensure backward compatibility with existing reminders
+- Ensure other operations (delete, edit) still work correctly with guild filtering
+
+## Files to Modify
+- `src/utils/storage.ts`
+- `src/services/reminderService.ts`
+- `src/commands/reminder.ts`
+- `src/__tests__/storage.test.ts`
+- `src/__tests__/reminderService.test.ts`

--- a/src/__tests__/reminderService.test.ts
+++ b/src/__tests__/reminderService.test.ts
@@ -209,6 +209,27 @@ describe('ReminderService', () => {
     });
   });
 
+  describe('getUserRemindersInGuild', () => {
+    it('should return reminders for a specific user in a specific guild', async () => {
+      const userGuildReminders = [mockReminder];
+      mockStorage.getRemindersByUserAndGuild.mockResolvedValue(userGuildReminders);
+
+      const result = await reminderService.getUserRemindersInGuild('user123', 'guild123');
+
+      expect(result).toEqual(userGuildReminders);
+      expect(mockStorage.getRemindersByUserAndGuild).toHaveBeenCalledWith('user123', 'guild123');
+    });
+
+    it('should return empty array when no reminders found for user in guild', async () => {
+      mockStorage.getRemindersByUserAndGuild.mockResolvedValue([]);
+
+      const result = await reminderService.getUserRemindersInGuild('user123', 'guild123');
+
+      expect(result).toEqual([]);
+      expect(mockStorage.getRemindersByUserAndGuild).toHaveBeenCalledWith('user123', 'guild123');
+    });
+  });
+
   describe('parseTimeString', () => {
     it('should parse relative time strings', () => {
       const result = reminderService.parseTimeString('30m');

--- a/src/__tests__/storage.test.ts
+++ b/src/__tests__/storage.test.ts
@@ -239,4 +239,38 @@ describe('ReminderStorage', () => {
       expect(activeReminders[0].isActive).toBe(true);
     });
   });
+
+  describe('getRemindersByUserAndGuild', () => {
+    it('should return reminders for specific user and guild', async () => {
+      const reminders = [
+        mockReminder, // user123, guild123
+        { ...mockReminder, id: 'test-id-2', userId: 'user456', guildId: 'guild123' }, // different user, same guild
+        { ...mockReminder, id: 'test-id-3', userId: 'user123', guildId: 'guild456' }, // same user, different guild
+        { ...mockReminder, id: 'test-id-4', userId: 'user456', guildId: 'guild456' }  // different user, different guild
+      ];
+      
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(JSON.stringify(reminders));
+      
+      const userGuildReminders = await storage.getRemindersByUserAndGuild('user123', 'guild123');
+      
+      expect(userGuildReminders).toHaveLength(1);
+      expect(userGuildReminders[0].userId).toBe('user123');
+      expect(userGuildReminders[0].guildId).toBe('guild123');
+      expect(userGuildReminders[0].id).toBe('test-id-1');
+    });
+
+    it('should return empty array when no reminders match user and guild', async () => {
+      const reminders = [
+        { ...mockReminder, userId: 'user456', guildId: 'guild456' }
+      ];
+      
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(JSON.stringify(reminders));
+      
+      const userGuildReminders = await storage.getRemindersByUserAndGuild('user123', 'guild123');
+      
+      expect(userGuildReminders).toHaveLength(0);
+    });
+  });
 });

--- a/src/commands/reminder.ts
+++ b/src/commands/reminder.ts
@@ -220,7 +220,16 @@ async function handleCreate(interaction: ChatInputCommandInteraction) {
 }
 
 async function handleList(interaction: ChatInputCommandInteraction) {
-  const reminders = await reminderService.getUserReminders(interaction.user.id);
+  // Handle DM context where guildId might be null
+  if (!interaction.guildId) {
+    await interaction.reply({
+      content: 'Reminder list command can only be used in a server, not in direct messages.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const reminders = await reminderService.getUserRemindersInGuild(interaction.user.id, interaction.guildId);
 
   if (reminders.length === 0) {
     await interaction.reply({

--- a/src/services/reminderService.ts
+++ b/src/services/reminderService.ts
@@ -114,6 +114,10 @@ export class ReminderService {
     return await this.storage.getRemindersByUser(userId);
   }
 
+  async getUserRemindersInGuild(userId: string, guildId: string): Promise<Reminder[]> {
+    return await this.storage.getRemindersByUserAndGuild(userId, guildId);
+  }
+
   parseTimeString(timeString: string): Date {
     // Handle relative time (e.g., "30m", "2h", "1d")
     const relativeTimeRegex = /^(\d+)([mhd])$/;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -84,6 +84,11 @@ export class ReminderStorage {
     return reminders.filter(r => r.userId === userId);
   }
 
+  async getRemindersByUserAndGuild(userId: string, guildId: string): Promise<Reminder[]> {
+    const reminders = await this.loadReminders();
+    return reminders.filter(r => r.userId === userId && r.guildId === guildId);
+  }
+
   async getActiveReminders(): Promise<Reminder[]> {
     const reminders = await this.loadReminders();
     return reminders.filter(r => r.isActive);


### PR DESCRIPTION
Filter reminder list results to show only reminders from the current guild instead of showing reminders from all guilds the user is in.

- Add getRemindersByUserAndGuild method to ReminderStorage
- Add getUserRemindersInGuild method to ReminderService
- Update handleList function to use guild-specific filtering
- Add proper DM context handling (guild-only command)
- Add comprehensive tests for new functionality

All existing tests pass, ensuring backward compatibility.