### PR TITLE
feat: add autocomplete for rotate template names

### DIFF
--- a/src/__tests__/rotate.test.ts
+++ b/src/__tests__/rotate.test.ts
@@ -1,5 +1,7 @@
+import type { AutocompleteInteraction } from 'discord.js';
 import type { Command } from '../command';
 import { selectParticipants } from '../utils/rotateHelpers';
+import { FacilitatorTemplateStorage } from '../utils/facilitatorTemplateStorage';
 
 describe('Rotate Command', () => {
   let command: Command;
@@ -182,5 +184,79 @@ describe('Rotate Command', () => {
     expect(message).toBe(
       'count must be less than the number of participants (got count=3 with 3 participants).',
     );
+  });
+
+  describe('template name autocomplete', () => {
+    function nameOptionOf(subcommandName: 'use' | 'delete'): { autocomplete?: boolean } {
+      const commandData = command.data.toJSON();
+      const templateGroup = commandData.options?.find((o) => o.name === 'template') as
+        | { options?: { name: string; options?: { name: string; autocomplete?: boolean }[] }[] }
+        | undefined;
+      const subcommand = templateGroup?.options?.find((o) => o.name === subcommandName);
+      const nameOption = subcommand?.options?.find((o) => o.name === 'name');
+      return nameOption as { autocomplete?: boolean };
+    }
+
+    test('template use name option has autocomplete enabled', () => {
+      expect(nameOptionOf('use')?.autocomplete).toBe(true);
+    });
+
+    test('template delete name option has autocomplete enabled', () => {
+      expect(nameOptionOf('delete')?.autocomplete).toBe(true);
+    });
+
+    test('handleAutocomplete is defined', () => {
+      expect(typeof command.handleAutocomplete).toBe('function');
+    });
+
+    test('responds with matching template names filtered by focused value', async () => {
+      const spy = jest
+        .spyOn(FacilitatorTemplateStorage.prototype, 'getTemplatesByGuild')
+        .mockResolvedValue([
+          {
+            id: '1',
+            guildId: 'guild-1',
+            name: 'Backend Team',
+            participants: ['Alice'],
+            selectionCounts: {},
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+          {
+            id: '2',
+            guildId: 'guild-1',
+            name: 'Frontend Team',
+            participants: ['Bob'],
+            selectionCounts: {},
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ]);
+
+      const respond = jest.fn();
+      const interaction = {
+        guildId: 'guild-1',
+        options: { getFocused: () => 'back' },
+        respond,
+      } as unknown as AutocompleteInteraction;
+
+      await command.handleAutocomplete!(interaction);
+
+      expect(respond).toHaveBeenCalledWith([{ name: 'Backend Team', value: 'Backend Team' }]);
+      spy.mockRestore();
+    });
+
+    test('responds with empty array when used outside a guild', async () => {
+      const respond = jest.fn();
+      const interaction = {
+        guildId: null,
+        options: { getFocused: () => '' },
+        respond,
+      } as unknown as AutocompleteInteraction;
+
+      await command.handleAutocomplete!(interaction);
+
+      expect(respond).toHaveBeenCalledWith([]);
+    });
   });
 });

--- a/src/command.ts
+++ b/src/command.ts
@@ -2,10 +2,12 @@ import type {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
   ModalSubmitInteraction,
+  AutocompleteInteraction,
 } from 'discord.js';
 
 export interface Command {
   data: SlashCommandBuilder;
   execute(interaction: ChatInputCommandInteraction): Promise<void>;
   handleModalSubmit?(interaction: ModalSubmitInteraction): Promise<void>;
+  handleAutocomplete?(interaction: AutocompleteInteraction): Promise<void>;
 }

--- a/src/commands/rotate.ts
+++ b/src/commands/rotate.ts
@@ -1,4 +1,8 @@
-import type { ChatInputCommandInteraction, ButtonInteraction } from 'discord.js';
+import type {
+  ChatInputCommandInteraction,
+  ButtonInteraction,
+  AutocompleteInteraction,
+} from 'discord.js';
 import {
   SlashCommandBuilder,
   ActionRowBuilder,
@@ -217,7 +221,11 @@ const command: Command = {
             .setName('use')
             .setDescription('Run the roulette using a saved template')
             .addStringOption((option) =>
-              option.setName('name').setDescription('Template name').setRequired(true),
+              option
+                .setName('name')
+                .setDescription('Template name')
+                .setRequired(true)
+                .setAutocomplete(true),
             )
             .addIntegerOption((option) =>
               option
@@ -232,7 +240,11 @@ const command: Command = {
             .setName('delete')
             .setDescription('Delete a saved template')
             .addStringOption((option) =>
-              option.setName('name').setDescription('Template name').setRequired(true),
+              option
+                .setName('name')
+                .setDescription('Template name')
+                .setRequired(true)
+                .setAutocomplete(true),
             ),
         )
         .addSubcommand((subcommand) =>
@@ -264,6 +276,23 @@ const command: Command = {
       // subcommand === 'run'
       await handleRun(interaction);
     }
+  },
+
+  async handleAutocomplete(interaction: AutocompleteInteraction) {
+    if (!interaction.guildId) {
+      await interaction.respond([]);
+      return;
+    }
+
+    const focused = interaction.options.getFocused().toLowerCase();
+    const templates = await templateStorage.getTemplatesByGuild(interaction.guildId);
+
+    const choices = templates
+      .filter((t) => t.name.toLowerCase().includes(focused))
+      .slice(0, 25)
+      .map((t) => ({ name: t.name, value: t.name }));
+
+    await interaction.respond(choices);
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,22 @@ async function main(): Promise<void> {
       return;
     }
 
+    // Handle autocomplete interactions
+    if (interaction.isAutocomplete()) {
+      const command = client.commands.get(interaction.commandName);
+
+      if (!command || !command.handleAutocomplete) {
+        return;
+      }
+
+      try {
+        await command.handleAutocomplete(interaction);
+      } catch (error) {
+        logger.error(`[ERROR] Error handling autocomplete for ${interaction.commandName}:`, error);
+      }
+      return;
+    }
+
     // Handle modal submit interactions
     if (interaction.isModalSubmit()) {
       const customId = interaction.customId;


### PR DESCRIPTION
Add Discord autocomplete to the name option on /rotate template
use and delete, suggesting saved templates for the current guild
as the user types.